### PR TITLE
Add image styles to transformationImages schema

### DIFF
--- a/_studio/schemas/documents/transformationImages.js
+++ b/_studio/schemas/documents/transformationImages.js
@@ -1,0 +1,47 @@
+export default {
+	name: 'transformationImages',
+	title: 'Transformation Images',
+	type: 'document',
+	fields: [
+	  {
+		 name: 'name',
+		 title: 'Name',
+		 type: 'string',
+		 description: 'Name of the transformation image',
+	  },
+	  {
+		 name: 'slug',
+		 title: 'Slug',
+		 type: 'slug',
+		 options: {
+			source: 'name',
+			maxLength: 200,
+		 },
+		 description: 'URL-friendly version of the name',
+	  },
+	  {
+		 name: 'image',
+		 title: 'Image',
+		 type: 'image',
+		 options: {
+			hotspot: true,
+		 },
+		 description: 'Image of the transformation',
+	  },
+	  {
+		 name: 'athlete',
+		 title: 'Athlete',
+		 type: 'reference',
+		 to: [{ type: 'athlete' }],
+		 description: 'Athlete associated with the transformation image',
+	  },
+	  {
+		 name: 'sport',
+		 title: 'Sport',
+		 type: 'reference',
+		 to: [{ type: 'sport' }],
+		 description: 'Sport associated with the transformation image',
+	  },
+	],
+ };
+ 

--- a/_studio/schemas/schemas.js
+++ b/_studio/schemas/schemas.js
@@ -1,4 +1,5 @@
 import sport from './documents/sport.js';
 import athletes from './documents/athletes.js';
+import transformationImages from './documents/transformationImages.js';
 
-export default [sport, athletes];
+export default [sport, athletes, transformationImages];


### PR DESCRIPTION
PR: Add Fields and Image Styles to transformationImages Schema

Updates:

* Add image styles to transformationImages schema


These updates enhance the transformationImages schema by adding necessary fields and image styles, enabling a more comprehensive representation of transformation images. 